### PR TITLE
Fix off-by-one error in patch adding getenv macro.

### DIFF
--- a/ncurses-6.1_emscripten.patch
+++ b/ncurses-6.1_emscripten.patch
@@ -17,7 +17,7 @@ diff -Naur ncurses-6.1/ncurses/curses.priv.h ncurses-6.1_emscripten/ncurses/curs
 +  int length = strlen(data);\
 +  char* dest = (char*)malloc(length+1);\
 +  strncpy(dest, data, length);\
-+  dest[length+1] = '\0';\
++  dest[length] = '\0';\
 +  dest;\
 +})
 +#endif


### PR DESCRIPTION
The compiled libraries should be updated as well.

The buffer is allocated with size length+1 and strncpy copies at most length bytes, so the terminating null char should be at index length (size it's zero based).

I've hit a bug where some seemingly unrelated memory allocs and processing on that memory cause an error in initscr(), which uses getenv to read TERM env. This could be due to an uninitialized extra char at the end of the terminal string and/or memory corruption due to the null byte overwriting internal malloc data structures interspersed with the allocated buffers.